### PR TITLE
Bump xercesImpl from 2.8.1 to 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <aes-model.version>1.5.0_06-64</aes-model.version>
         <audiomarker.version>1.6.0_65-b14-462-11M4609</audiomarker.version>
         <jdom.version>2.0.6.1</jdom.version>
-        <xercesImpl.version>2.8.1</xercesImpl.version>
+        <xercesImpl.version>2.12.2</xercesImpl.version>
         <saxonhe.version>9.8.0-10</saxonhe.version>
         <castor.version>0.9.5.4</castor.version>
         <commons-csv.version>1.0</commons-csv.version>


### PR DESCRIPTION
### Description

The change in this pull request updates the version of the xercesImpl library from 2.8.1 to 2.12.2 in the pom.xml file.

Summary of changes:
- Updated xercesImpl version from 2.8.1 to 2.12.2 in the pom.xml file.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump the `xercesImpl` library version from 2.8.1 to 2.12.2 in the `pom.xml` file.

### Why are these changes being made?

This update addresses potential security vulnerabilities and improves compatibility with newer XML standards. Upgrading to the latest stable version ensures better performance and support for recent features and bug fixes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->